### PR TITLE
Build fedora atomic 27 image using diskimage-builder 2.12.2 on Centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-See [setup.sh](setup.sh).
+# Usage
+
+```
+INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/[setup.sh](setup.sh)
+```
+
+`INSTALL DEPS=1` installs all the required packages to run diskimage-builder. It is only necessary to include it once.
+
+# Goal:
+- building Fedora Atomic 27 image
+- using diskimage-builder 2.12.2
+- on Centos 7
+
+# Result:
+- modified [existing instructions][existing] for diskimage-builder 2.3.3 to build Fedora Atomic 25 image
+
+# Problems:
+- Still need to put selinux into permissive mode on grub config in order to successfully boot into the image.
+- Can't use the 'baremetal' element as fedora-atomic depends on vm element.
+- Can't use dracut-network/dracut-regenerate as fedora-atomic cleanup removes dracut (https://bugs.launchpad.net/magnum/+bug/1699771).
+- Have to manually specify kernel & initrd pattern for dracut-network/dracut-regenerate.
+- Specifying DIB_RELEASE=25 does not give you a fedora atomic 25 image (https://bugs.launchpad.net/magnum/+bug/1699766).
+
+[existing]: http://paste.openstack.org/show/613376 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 To build the image:
 
-	INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/[setup.sh](setup.sh)
+	INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/setup.sh
 
 `INSTALL DEPS=1` installs all the required packages to run diskimage-builder. It is only necessary to include it the first time.
 
 To boot into the image:
 
-	./fedora-atomic-dib/[gencloudinitiso.sh](gencloudinitiso.sh)
-	DIB_RELEASE=27 sudo -E ./fedora-atomic-dib/[qemu.sh](qemu.sh)
+	./fedora-atomic-dib/gencloudinitiso.sh
+	DIB_RELEASE=27 sudo -E ./fedora-atomic-dib/qemu.sh
 
 # Goal:
 - building Fedora Atomic 27 image

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Usage
 
+To build the image:
+
 ```
 INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/[setup.sh](setup.sh)
 ```
 
-`INSTALL DEPS=1` installs all the required packages to run diskimage-builder. It is only necessary to include it once.
+`INSTALL DEPS=1` installs all the required packages to run diskimage-builder. It is only necessary to include it the first time.
+
+To boot into the image:
+
+```
+./fedora-atomic-dib/gencloudinitiso.sh
+DIB_RELEASE=27 sudo -E ./fedora-atomic-dib/qemu.sh
+```
 
 # Goal:
 - building Fedora Atomic 27 image

--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 To build the image:
 
-```
-INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/[setup.sh](setup.sh)
-```
+	INSTALL_DEPS=1 DIB_RELEASE=27 ./fedora_atomic_dib/[setup.sh](setup.sh)
 
 `INSTALL DEPS=1` installs all the required packages to run diskimage-builder. It is only necessary to include it the first time.
 
 To boot into the image:
 
-```
-./fedora-atomic-dib/gencloudinitiso.sh
-DIB_RELEASE=27 sudo -E ./fedora-atomic-dib/qemu.sh
-```
+	./fedora-atomic-dib/[gencloudinitiso.sh](gencloudinitiso.sh)
+	DIB_RELEASE=27 sudo -E ./fedora-atomic-dib/[qemu.sh](qemu.sh)
 
 # Goal:
 - building Fedora Atomic 27 image

--- a/cloud-init/meta-data
+++ b/cloud-init/meta-data
@@ -1,0 +1,2 @@
+instance-id: Atomic01
+local-hostname: atomic-host-001

--- a/cloud-init/user-data
+++ b/cloud-init/user-data
@@ -1,0 +1,6 @@
+#cloud-config
+password: redhat
+chpasswd: { expire: False }
+ssh_pwauth: True 
+ssh_authorized_keys:
+  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDC6zhRqvv2YnLEzRsxaRn/GgzDy4DOaZW9+zNEE5zBtaVnXe90S1hIMke2VNL58CVMrBgXpdx1f+KuDBvc3dVqDrDxpC+BLL5X/9l4en4a6CUs+GhZMcCDfpKKPX57V5q1eKs3cD9zMp3nnXqaMA+HIs2CQxNnm7JjakgueT7CDhV5xcEWLKnnUqDPs1W8E1STIXRpWDExoFUoEa5WaP21fhg/cIUXZPBCRk31TBVwMnpqmqhZ5ajriXUCKcXT9iRrdsMKlr4t/zQVek6GMxlj+dZxuFhnoeCBcoki7Jh3+EkjW6FbZd1aQrkkk54jAUyUpNPc/fNJvurHtVUjTYEX centos@k8s-2.novalocal

--- a/gencloudinitiso.sh
+++ b/gencloudinitiso.sh
@@ -1,0 +1,1 @@
+genisoimage -output cidata.iso -volid cidata -joliet -rock fedora-atomic-dib/cloud-init/user-data fedora-atomic-dib/cloud-init/meta-data

--- a/qemu.sh
+++ b/qemu.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+qemu-system-x86_64 -nographic -cdrom cidata.iso baremetal-${DIB_RELEASE}.qcow2 -m 2048 -net user,hostfwd=tcp::1234-:22 -net nic --enable-kvm

--- a/setup.sh
+++ b/setup.sh
@@ -1,54 +1,43 @@
 #!/bin/bash
 
-# Goal:
-# Use a fedora atomic image to deploy a k8s cluster on bare metal
-# using magnum @ ocata and the k8s_fedora_atomic_v1 (VM) driver.
+if [ INSTALL_DEPS == 1 ]; then
+	# Most image formats require the qemu-img tool which is provided by the qemu-utils package on Ubuntu/Debian or the qemu package on Fedora/RHEL/opensuse/Gentoo.
+	# When generating images with partitions, the kpartx tool is needed, which is provided by the kpartx package.
+	sudo yum -y install qemu kpartxg git
 
-# Result:
-# Got there in the end...
-# Required some small code changes, created some bugs, will push patches.
+	# Install python and its dependencies
+	sudo yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+	sudo yum -y install python36u python36u-pip python36u-devel tmux2u
+	pip3.6 install --user virtualenv
 
-# Problems:
-# - fedora-atomic DIB element doesn't work with latest DIB (https://bugs.launchpad.net/magnum/+bug/1699735)
-# - Can't use the 'baremetal' element as fedora-atomic depends on vm element.
-# - Can't use dracut-network/dracut-regenerate as fedora-atomic cleanup removes dracut (https://bugs.launchpad.net/magnum/+bug/1699771).
-# - Have to manually specify kernel & initrd pattern for dracut-network/dracut-regenerate.
-# - Fedora-atomic element instructions build a fedora atomic 24 image by default which doesn't work on ocata magnum (https://bugs.launchpad.net/magnum/+bug/1699765).
-# - Specifying DIB_RELEASE=25 does not give you a fedora atomic 25 image (https://bugs.launchpad.net/magnum/+bug/1699766).
+	# Clone these repos
+	git clone https://git.openstack.org/openstack/magnum
 
-# Most image formats require the qemu-img tool which is provided by the qemu-utils package on Ubuntu/Debian or the qemu package on Fedora/RHEL/opensuse/Gentoo.
-# When generating images with partitions, the kpartx tool is needed, which is provided by the kpartx package.
-sudo yum -y install qemu kpartxg git
+	git clone -b fedora-atomic https://github.com/brtknr/magnum.git 
+	git clone https://git.openstack.org/openstack/dib-utils.git
+	git clone https://git.openstack.org/openstack/diskimage-builder
 
-# Install python and its dependencies
-sudo yum -y install https://centos7.iuscommunity.org/ius-release.rpm
-sudo yum -y install python36u python36u-pip python36u-devel tmux2u
-pip3.6 install --user virtualenv
+	# Install diskimage-builder
+	pushd diskimage-builder && pip install -e . && popd
+
+	# The following magnum patch to make dracut-regenerate work has been applied to fedora-atomic branch of brtknr/magnum
+	pushd magnum && git fetch https://git.openstack.org/openstack/magnum refs/changes/13/476513/1 && popd
+fi
+
 virtualenv ~/dib-virtualenv
 source ~/dib-virtualenv/bin/activate
-tmux
 
-# Clone these repos
-git clone https://git.openstack.org/openstack/magnum
-
-git clone -b fedora-atomic https://github.com/brtknr/magnum.git 
-git clone https://git.openstack.org/openstack/dib-utils.git
-git clone https://git.openstack.org/openstack/diskimage-builder
-
-pushd diskimage-builder && pip install -e . && popd
-
-# The following magnum patch to make dracut-regenerate work has been applied to fedora-atomic branch of brtknr/magnum
-# pushd magnum && git fetch https://git.openstack.org/openstack/magnum refs/changes/13/476513/1 && popd
+rsync -rp ${PWD}/diskimage-builder/diskimage_builder/elements/fedora-atomic/ ${PWD}/magnum/magnum/drivers/common/image/fedora-atomic/
 
 export PATH="${PWD}/dib-utils/bin:$PATH"
-export DIB_RELEASE=27
+export DIB_RELEASE=${DIB_RELEASE}
 export DIB_IMAGE_SIZE=2.5
 
 # Without these the select-initrd-kernel-image element fails as the
 # fedora-atomic ramdisk and kernel are not in /boot. This element is a dependency
 # of dracut-network/dracut-regenerate.
-export DIB_BAREMETAL_KERNEL_PATTERN='ostree/fedora-atomic-*/vmlinuz*'
-export DIB_BAREMETAL_INITRD_PATTERN='ostree/fedora-atomic-*/initramfs-*'
+#export DIB_BAREMETAL_KERNEL_PATTERN='ostree/fedora-atomic-*/vmlinuz*'
+#export DIB_BAREMETAL_INITRD_PATTERN='ostree/fedora-atomic-*/initramfs-*'
 
 # This is not currently being used
 export ELEMENTS_PATH=$(python -c 'import os, diskimage_builder, pkg_resources;print(os.path.abspath(pkg_resources.resource_filename(diskimage_builder.__name__, "elements")))')
@@ -57,20 +46,20 @@ export ELEMENTS_PATH=$(python -c 'import os, diskimage_builder, pkg_resources;pr
 export ELEMENTS_PATH="${PWD}/diskimage-builder/diskimage_builder/elements"
 export ELEMENTS_PATH="${ELEMENTS_PATH}:${PWD}/magnum/magnum/drivers/common/image"
 
+# Elements we wantt o include
 ELEMENTS="\
-vm \
 dhcp-all-interfaces \
 enable-serial-console \
 dracut-regenerate \
-selinux-permissive \
 fedora-atomic \
+vm \
 "
-export DIB_DEBUG_TRACE
 
 sudo setenforce Permissive
 
-export FEDORA_ATOMIC_TREE_URL="https://kojipkgs.fedoraproject.org/atomic/${DIB_RELEASE}/"
-export FEDORA_ATOMIC_TREE_REF="$(curl ${FEDORA_ATOMIC_TREE_URL}/refs/heads/fedora/${DIB_RELEASE}/x86_64/atomic-host)"
-
 export DIB_DEBUG_TRACE=1 
-disk-image-create -p python3-PyYAML -p PyYAML $ELEMENTS -o k9s-fedora-atomic-$DIB_RELEASE.qcow2 | tee dib-uuid27.log
+#export break=before-root,before-extra-data,before-pre-install,before-install,before-post-install,before-block-device,before-finalise,before-cleanup
+
+export break=after-error
+
+disk-image-create $ELEMENTS -o baremetal-${DIB_RELEASE}.qcow2 | tee baremetal-${DIB_RELEASE}.log

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,6 @@ if [ INSTALL_DEPS == 1 ]; then
 
 	# Clone these repos
 	git clone https://git.openstack.org/openstack/magnum
-
-	git clone -b fedora-atomic https://github.com/brtknr/magnum.git 
 	git clone https://git.openstack.org/openstack/dib-utils.git
 	git clone https://git.openstack.org/openstack/diskimage-builder
 

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ rsync -rp ${PWD}/diskimage-builder/diskimage_builder/elements/fedora-atomic/ ${P
 
 export PATH="${PWD}/dib-utils/bin:$PATH"
 export DIB_RELEASE=${DIB_RELEASE}
-export DIB_IMAGE_SIZE=2.5
+export DIB_IMAGE_SIZE=3.0
 
 # Without these the select-initrd-kernel-image element fails as the
 # fedora-atomic ramdisk and kernel are not in /boot. This element is a dependency


### PR DESCRIPTION
* building Fedora Atomic 27 image
* using diskimage-builder 2.12.2
* on Centos 7